### PR TITLE
Dungeons can now spawn in stars

### DIFF
--- a/Content.Server/_FTL/FTLPoints/Effects/SpawnDungeonEffect.cs
+++ b/Content.Server/_FTL/FTLPoints/Effects/SpawnDungeonEffect.cs
@@ -1,0 +1,61 @@
+using Content.Server.Procedural;
+using Content.Shared.Maps;
+using Content.Shared.Procedural;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+
+namespace Content.Server._FTL.FTLPoints.Effects;
+
+[DataDefinition]
+public sealed class SpawnDungeonEffect : FTLPointEffect
+{
+    [DataField("configPrototypes", required: true)]
+    public List<string> ConfigPrototypes { get; } = new List<string>()
+    {
+        "Experiment",
+        "LavaBrig",
+    };
+
+    [DataField("maxSpawn")] public int MinSpawn = 1;
+    [DataField("minSpawn")] public int MaxSpawn = 2;
+
+    public override void Effect(FTLPointEffectArgs args)
+    {
+        var random = IoCManager.Resolve<IRobustRandom>();
+        var amountToSpawn = random.Next(MinSpawn, MaxSpawn);
+
+        for (int i = 0; i < amountToSpawn; i++)
+        {
+            var dungeon = args.EntityManager.System<DungeonSystem>();
+            var prototype = IoCManager.Resolve<IPrototypeManager>();
+
+            var position = new Vector2i(random.Next(-200, 200), random.Next(-200, 200));
+            var dungeonUid = args.MapManager.GetMapEntityId(args.MapId);
+
+            if (!args.EntityManager.TryGetComponent<MapGridComponent>(dungeonUid, out var dungeonGrid))
+            {
+                dungeonUid = args.EntityManager.CreateEntityUninitialized(null, new EntityCoordinates(dungeonUid, position));
+                dungeonGrid = args.EntityManager.AddComponent<MapGridComponent>(dungeonUid);
+                args.EntityManager.InitializeAndStartEntity(dungeonUid, args.MapId);
+            }
+
+            int seed = new Random().Next();
+
+            if (!prototype.TryIndex<DungeonConfigPrototype>(random.Pick(ConfigPrototypes), out var dungeonProto))
+            {
+                return;
+            }
+
+            dungeon.GenerateDungeon(dungeonProto, dungeonUid, dungeonGrid, position, seed);
+
+            foreach (var tile in dungeonGrid.GetAllTiles())
+            {
+                var def = tile.GetContentTileDefinition();
+                var newTile = new Tile(tile.Tile.TypeId, tile.Tile.Flags, random.Pick(def.PlacementVariants));
+                dungeonGrid.SetTile(tile.GridIndices, newTile);
+            }
+        }
+    }
+}

--- a/Content.Server/_FTL/FTLPoints/Effects/SpawnDungeonEffect.cs
+++ b/Content.Server/_FTL/FTLPoints/Effects/SpawnDungeonEffect.cs
@@ -18,8 +18,8 @@ public sealed class SpawnDungeonEffect : FTLPointEffect
         "LavaBrig",
     };
 
-    [DataField("maxSpawn")] public int MinSpawn = 1;
-    [DataField("minSpawn")] public int MaxSpawn = 2;
+    [DataField("minSpawn")] public int MinSpawn = 1;
+    [DataField("maxSpawn")] public int MaxSpawn = 2;
 
     public override void Effect(FTLPointEffectArgs args)
     {

--- a/Content.Server/_FTL/FTLPoints/Effects/SpawnDungeonEffect.cs
+++ b/Content.Server/_FTL/FTLPoints/Effects/SpawnDungeonEffect.cs
@@ -11,7 +11,7 @@ namespace Content.Server._FTL.FTLPoints.Effects;
 [DataDefinition]
 public sealed class SpawnDungeonEffect : FTLPointEffect
 {
-    [DataField("configPrototypes", required: true)]
+    [DataField("configPrototypes")]
     public List<string> ConfigPrototypes { get; } = new List<string>()
     {
         "Experiment",

--- a/Content.Server/_FTL/FTLPoints/FTLPointEffect.cs
+++ b/Content.Server/_FTL/FTLPoints/FTLPointEffect.cs
@@ -10,6 +10,7 @@ namespace Content.Server._FTL.FTLPoints;
 [ImplicitDataDefinitionForInheritors, MeansImplicitUse]
 public abstract class FTLPointEffect
 {
+    [DataField("probability")] public float Probability = 1f;
     public abstract void Effect(FTLPointEffectArgs args);
 
     public readonly record struct FTLPointEffectArgs(

--- a/Content.Server/_FTL/FTLPoints/FTLPointsSystem.cs
+++ b/Content.Server/_FTL/FTLPoints/FTLPointsSystem.cs
@@ -72,11 +72,14 @@ public sealed class FTLPointsSystem : EntitySystem
         // create map
         if (point.OverrideSpawn == null)
         {
+            if (!_random.Prob(point.Probability))
+                return;
+
             var mapId = _mapManager.CreateMap();
             _mapManager.AddUninitializedMap(mapId);
             var mapUid = _mapManager.GetMapEntityId(mapId);
             _metaDataSystem.SetEntityName(mapUid, $"[{Loc.GetString(point.Tag)}] {
-                SharedSalvageSystem.GetFTLName(_prototypeManager.Index<DatasetPrototype>("names_borer"), _random.Next(0, 1000000))}");
+                SharedSalvageSystem.GetFTLName(_prototypeManager.Index<DatasetPrototype>("names_borer"), _random.Next())}");
 
             // make it ftlable
             EnsureComp<FTLDestinationComponent>(mapUid);
@@ -98,7 +101,10 @@ public sealed class FTLPointsSystem : EntitySystem
             // spawn the stuff
             foreach (var effect in point.FtlPointEffects)
             {
-                effect.Effect(new FTLPointEffect.FTLPointEffectArgs(mapUid, mapId, _entManager, _mapManager));
+                if (_random.Prob(effect.Probability))
+                {
+                    effect.Effect(new FTLPointEffect.FTLPointEffectArgs(mapUid, mapId, _entManager, _mapManager));
+                }
             }
         }
         else

--- a/Resources/Locale/en-US/_ftl/ships.ftl
+++ b/Resources/Locale/en-US/_ftl/ships.ftl
@@ -9,3 +9,5 @@ ship-ftl-tag-base = BASE
 ship-ftl-tag-danger = !!!!
 ship-ftl-tag-unknown = ????
 ship-ftl-tag-planet = PLNT
+ship-ftl-tag-ruin = RUIN
+ship-ftl-tag-yard = YARD

--- a/Resources/Prototypes/_FTL/ftl_points.yml
+++ b/Resources/Prototypes/_FTL/ftl_points.yml
@@ -39,15 +39,37 @@
   tag: ship-ftl-tag-planet
   effects:
     - !type:ToPlanetEffect
+    - !type:SpawnDungeonEffect
+      probability: 0.7
+      minSpawn: 1
+      maxSpawn: 3
 
 - type: ftlPoint
   id: StarPoint
-  tag: ship-ftl-tag-star # these and NoDangerPoint are the exact same just with a difference in tag
-  effects: []
+  tag: ship-ftl-tag-star
+  effects:
+    - !type:SpawnDungeonEffect
+      probability: 0.7
+      maxSpawn: 6
+
+- type: ftlPoint
+  id: RuinPoint
+  tag: ship-ftl-tag-ruin
+  effects:
+    - !type:SpawnDungeonEffect
+
+- type: ftlPoint
+  id: YardPoint
+  tag: ship-ftl-tag-yard
+  effects:
+    - !type:SpawnDungeonEffect
+      probability: 0.7
+      minSpawn: 5
+      maxSpawn: 10
 
 - type: ftlPoint
   id: NoDangerPoint
-  tag: ship-ftl-tag-unknown # these and StarPoint are the exact same just with a difference in tag
+  tag: ship-ftl-tag-unknown
   effects: []
 
 - type: weightedRandom
@@ -60,3 +82,5 @@
     ConfDangerPoint: 3
     StarPoint: 1
     PlanetPoint: 1
+    RuinPoint: 0.25
+    YardPoint: 0.25


### PR DESCRIPTION
Adds the shipyard point and the ruin point with guaranteed dungeon spawns, along with chances for ruins to spawn on planets and regular stars (to spice them up)
![image](https://github.com/Just-a-Unity-Dev/ekrixi/assets/67359748/6c37630f-a291-4b67-967b-e326216afefb)
